### PR TITLE
enhance file name parsing for STAR/HISAT2

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -1053,7 +1053,7 @@ if (!params.skipAlignment) {
           file "${prefix}Aligned.sortedByCoord.out.bam.bai" into bam_index_rseqc, bam_index_genebody
 
           script:
-          prefix = reads[0].toString() - ~/(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?$/
+          prefix = reads[0].toString() - ~/(_1)?(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?$/
           def star_mem = task.memory ?: params.star_memory ?: false
           def avail_mem = star_mem ? "--limitBAMsortRAM ${star_mem.toBytes() - 100000000}" : ''
           seq_center = params.seq_center ? "--outSAMattrRGline ID:$prefix 'CN:$params.seq_center' 'SM:$prefix'" : "--outSAMattrRGline ID:$prefix 'SM:$prefix'"
@@ -1111,7 +1111,7 @@ if (!params.skipAlignment) {
 
           script:
           index_base = hs2_indices[0].toString() - ~/.\d.ht2l?/
-          prefix = reads[0].toString() - ~/(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?$/
+          prefix = reads[0].toString() - ~/(_1)?(_R1)?(_trimmed)?(_val_1)?(\.fq)?(\.fastq)?(\.gz)?$/
           seq_center = params.seq_center ? "--rg-id ${prefix} --rg CN:${params.seq_center.replaceAll('\\s','_')} SM:$prefix" : "--rg-id ${prefix} --rg SM:$prefix"
           def rnastrandness = ''
           if (forwardStranded && !unStranded) {


### PR DESCRIPTION
enhance file name parsing to obtain the correct prefix string for STAR/HISAT2 align:
currently the pipeline only recognizes file names such as "SRR1234_R1.fq.gz" and "SRR1234_R2.fq.gz";
it does not recognize SRR1234_1.fq.gz or SRR1234_2.fq.gz
this patch offers a quick fix

Many thanks to contributing to nf-core/rnaseq!

To ensure that your build passes, please make sure your pull request is to the `dev` branch rather than to `master`. Thank you!

Please fill in the appropriate checklist below (delete whatever is not relevant). These are the most common things requested on pull requests (PRs).

## PR checklist
 - [ x] PR is to `dev` rather than `master`
 - [ x] This comment contains a description of changes (with reason)
 - [ ] If you've fixed a bug or added code that should be tested, add tests!
 - [ ] If necessary, also make a PR on the [nf-core/rnaseq branch on the nf-core/test-datasets repo]( https://github.com/nf-core/test-datasets/pull/new/nf-core/rnaseq)
 - [ ] Ensure the test suite passes (`nextflow run . -profile test,docker`).
 - [ ] Make sure your code lints (`nf-core lint .`).
 - [ ] Documentation in `docs` is updated
 - [ ] `CHANGELOG.md` is updated
 - [ ] `README.md` is updated

**Learn more about contributing:** https://github.com/nf-core/rnaseq/tree/master/.github/CONTRIBUTING.md
